### PR TITLE
Fix templates

### DIFF
--- a/Sources/AdminPanel/Support/LeafTags/FormCheckboxGroup.swift
+++ b/Sources/AdminPanel/Support/LeafTags/FormCheckboxGroup.swift
@@ -101,9 +101,9 @@ public class FormCheckboxGroup: BasicTag {
         template.append("<label>")
         
         if(inputValue == true) {
-            template.append("<input type='checkbox' id='\(inputName)' name='\(inputName)' value='\(inputName)' checked/>")
+            template.append("<input type='checkbox' id='\(inputName)' name='\(inputName)' value='\(inputName)' checked")
         } else {
-            template.append("<input type='checkbox' id='\(inputName)' name='\(inputName)' value='\(inputName)")
+            template.append("<input type='checkbox' id='\(inputName)' name='\(inputName)' value='\(inputName)'")
         }
         
         // Add custom attributes

--- a/Sources/AdminPanel/Support/LeafTags/FormSelectGroup.swift
+++ b/Sources/AdminPanel/Support/LeafTags/FormSelectGroup.swift
@@ -96,8 +96,6 @@ public class FormSelectGroup: BasicTag {
         
         template.append("</select>")
         
-        template.append("</div>")
-        
         // If Fieldset has errors then loop through them and add help-blocks
         if(errors != nil) {
             for e in errors! {


### PR DESCRIPTION
Fixed bug in FormCheckboxGroup template (tag was closed twice).
Fix FormSelectGroup template. Remove unpaired closing div tag.