### PR TITLE
Add multiple databases support

### DIFF
--- a/Sources/AdminPanel/Models/BackendUsers/BackendUser.swift
+++ b/Sources/AdminPanel/Models/BackendUsers/BackendUser.swift
@@ -125,16 +125,17 @@ public final class BackendUser: Auth.User, Model {
     public static func prepare(_ database: Database) throws {
         try database.create("backend_users") { table in
             table.id()
-            table.varchar("name", length: 191)
-            table.varchar("email", length: 191, unique: true)
-            table.varchar("password", length: 191)
-            table.varchar("role", length: 191)
-            table.varchar("image", length: 191, optional: true)
+            table.string("name", length: 191)
+            table.string("email", length: 191, unique: true)
+            table.string("password", length: 191)
+            table.string("role", length: 191)
+            table.string("image", length: 191, optional: true)
             table.bool("should_reset_password", default: Node(false))
-            table.timestamps()
+            table.string("created_at", optional: false)
+            table.string("updated_at", optional: false)
         }
         
-        try database.index(table: "backend_users", column: "email")
+        try? database.index(table: "backend_users", column: "email")
     }
     
     public static func revert(_ database: Database) throws {

--- a/Sources/AdminPanel/Models/BackendUsers/BackendUserResetPasswordTokens/BackendUserResetPasswordTokens.swift
+++ b/Sources/AdminPanel/Models/BackendUsers/BackendUserResetPasswordTokens/BackendUserResetPasswordTokens.swift
@@ -65,15 +65,16 @@ public final class BackendUserResetPasswordTokens: Model {
     public static func prepare(_ database: Database) throws {
         try database.create("backend_reset_password_tokens") { table in
             table.id()
-            table.varchar("email", length: 191, unique: true)
-            table.varchar("token", length: 191)
-            table.datetime("used_at", optional: true)
-            table.datetime("expire_at", optional: true)
-            table.timestamps()
+            table.string("email", length: 191, unique: true)
+            table.string("token", length: 191)
+            table.string("used_at", optional: true)
+            table.string("expire_at", optional: true)
+            table.string("created_at", optional: false)
+            table.string("updated_at", optional: false)
         }
         
-        try database.index(table: "backend_reset_password_tokens", column: "email")
-        try database.index(table: "backend_reset_password_tokens", column: "token")
+        try? database.index(table: "backend_reset_password_tokens", column: "email")
+        try? database.index(table: "backend_reset_password_tokens", column: "token")
     }
     
     public static func revert(_ database: Database) throws {


### PR DESCRIPTION
Creating an index on Postgresql table results in a crash. I believe that we can still benefit from indexing on Mysql, while not dropping the support for other database providers.