### PR TITLE
Use Fluent's index functionality 

### DIFF
--- a/Sources/AdminPanel/Models/BackendUsers/BackendUser.swift
+++ b/Sources/AdminPanel/Models/BackendUsers/BackendUser.swift
@@ -139,7 +139,7 @@ public final class BackendUser: Model, Timestampable, NodeConvertible, Preparati
             table.bool("shouldResetPassword", default: Node(false))
         }
         
-        try database.index(table: "backend_users", column: "email")
+        try database.index("email", for: self)
     }
     
     public static func revert(_ database: Database) throws {

--- a/Sources/AdminPanel/Models/BackendUsers/BackendUserResetPasswordTokens/BackendUserResetPasswordTokens.swift
+++ b/Sources/AdminPanel/Models/BackendUsers/BackendUserResetPasswordTokens/BackendUserResetPasswordTokens.swift
@@ -59,9 +59,9 @@ public final class BackendUserResetPasswordTokens: Model, Timestampable, Prepara
             table.datetime("used_at", optional: true)
             table.datetime("expire_at", optional: true)
         }
-        
-        try database.index(table: "backend_reset_password_tokens", column: "email")
-        try database.index(table: "backend_reset_password_tokens", column: "token")
+
+        try database.index("email", for: self)
+        try database.index("token", for: self)
     }
     
     public static func revert(_ database: Database) throws {


### PR DESCRIPTION
This uses Fluent's built in index functionality. This makes it database agnostic (ie. doesn't crash SQLite). The index helpers in Sugar should probably be removed or at least deprecated.