### PR TITLE
validatable password reset + leaf improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,66 @@
+version: 2
+jobs:
+  MacOS:
+    macos:
+      xcode: "9.3.0"
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v3-spm-deps-{{ checksum "Package.swift" }}
+      - run:
+          name: Install CMySQL and CTLS
+          command: |
+            brew tap vapor/homebrew-tap
+            brew install cmysql
+            brew install ctls
+            brew install libressl
+      - run:
+          name: Build and Run Tests
+          no_output_timeout: 1800
+          command: |
+            swift package generate-xcodeproj --enable-code-coverage    
+            xcodebuild -scheme AdminPanel-Package -enableCodeCoverage YES test | xcpretty
+      - run:
+          name: Report coverage to Codecov
+          command: |
+            bash <(curl -s https://codecov.io/bash)
+      - save_cache:
+          key: v1-spm-deps-{{ checksum "Package.swift" }}
+          paths:
+            - .build
+  Linux:
+    docker:
+      - image: nodesvapor/vapor-ci:swift-4.1
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v4-spm-deps-{{ checksum "Package.swift" }}
+      - run:
+          name: Copy Package file
+          command: cp Package.swift res
+      - run:
+          name: Build and Run Tests
+          no_output_timeout: 1800
+          command: |
+            swift test -Xswiftc -DNOJSON
+      - run:
+          name: Restoring Package file
+          command: mv res Package.swift
+      - save_cache:
+          key: v2-spm-deps-{{ checksum "Package.swift" }}
+          paths:
+            - .build
+workflows:
+  version: 2
+  build-and-test:
+    jobs:
+      - MacOS
+      - Linux
+experimental:
+  notify:
+    branches:
+      only:
+        - master
+        - develop

--- a/.codebeatignore
+++ b/.codebeatignore
@@ -1,0 +1,2 @@
+Public/**
+Resources/Assets/**

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  range: "0...100"
+  ignore:
+    - "Tests"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,12 @@
+included:
+  - Sources
+function_body_length:
+  warning: 60
+identifier_name:
+  min_length:
+    warning: 2
+line_length: 100
+disabled_rules:
+  - opening_brace
+colon:
+  flexible_right_spacing: true

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016-2018 Nodes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Resources/Views/AdminPanel/AdminPanelUser/edit.leaf
+++ b/Resources/Views/AdminPanel/AdminPanelUser/edit.leaf
@@ -21,9 +21,9 @@
     }
         <h4>User details</h4>
 
-        #submissions:input("name", "text", "Enter name")
-        #submissions:input("title", "text", "Enter title")
-        #submissions:input("email", "email", "Enter email")
+        #submissions:text("name", "Enter name")
+        #submissions:text("title", "Enter title")
+        #submissions:email("email", "Enter email")
 
         <hr>
 
@@ -33,9 +33,8 @@
             <p>Leaving the password fields blank will auto-generate a password for the user.</p>
         }
 
-        #submissions:input("password", "password", "Enter password", "Minimum 8 characters.")
-        #submissions:input("passwordAgain", "password", "Enter password again")
-  
+        #submissions:password("password", "Enter password", "Minimum 8 characters.")
+        #submissions:password("passwordAgain", "Enter password again")
 
         #if(user == nil) {
             <div class="form-group form-check">

--- a/Sources/AdminPanel/Configs/AdminPanelConfig.swift
+++ b/Sources/AdminPanel/Configs/AdminPanelConfig.swift
@@ -1,11 +1,11 @@
 import Fluent
 import Vapor
 
-public struct AdminPanelConfig: Service {
+public struct AdminPanelConfig<U: AdminPanelUserType>: Service {
     let name: String
     let baseUrl: String
     let endpoints: AdminPanelEndpoints
-    let controllers: AdminPanelControllers
+    let controllers: AdminPanelControllers<U>
     let userMenuPath: String?
     let adminMenuPath: String?
     let superAdminMenuPath: String?
@@ -14,8 +14,8 @@ public struct AdminPanelConfig: Service {
     public init(
         name: String,
         baseUrl: String,
-        endpoints: AdminPanelEndpoints = AdminPanelEndpoints.default,
-        controllers: AdminPanelControllers = .default,
+        endpoints: AdminPanelEndpoints = .default,
+        controllers: AdminPanelControllers<U> = .default,
         userMenuPath: String? = nil,
         adminMenuPath: String? = nil,
         superAdminMenuPath: String? = nil,
@@ -32,7 +32,7 @@ public struct AdminPanelConfig: Service {
     }
 }
 
-public struct AdminPanelControllers {
+public struct AdminPanelControllers<U: AdminPanelUserType> {
     public let loginController: LoginControllerType
     public let dashboardController: DashboardControllerType
     public let adminPanelUserController: AdminPanelUserControllerType
@@ -51,9 +51,9 @@ public struct AdminPanelControllers {
 extension AdminPanelControllers {
     public static var `default`: AdminPanelControllers {
         return .init(
-            loginController: LoginController<AdminPanelUser>(),
-            dashboardController: DashboardController(),
-            adminPanelUserController: AdminPanelUserController<AdminPanelUser>()
+            loginController: LoginController<U>(),
+            dashboardController: DashboardController<U>(),
+            adminPanelUserController: AdminPanelUserController<U>()
         )
     }
 }

--- a/Sources/AdminPanel/Controllers/AdminPanelUserController.swift
+++ b/Sources/AdminPanel/Controllers/AdminPanelUserController.swift
@@ -57,7 +57,7 @@ where
                         .success,
                         """
                         The user with email '\(user[keyPath: U.usernameKey])'
-                         got created successfully.
+                        was created successfully.
                         """
                     )
             }

--- a/Sources/AdminPanel/Controllers/AdminPanelUserController.swift
+++ b/Sources/AdminPanel/Controllers/AdminPanelUserController.swift
@@ -16,10 +16,6 @@ public protocol AdminPanelUserControllerType {
 
 public final class AdminPanelUserController
     <U: AdminPanelUserType>: AdminPanelUserControllerType
-where
-    U: Submittable,
-    U.ResolvedParameter == Future<U>,
-    U.ID: LosslessStringConvertible
 {
     public init() {}
 

--- a/Sources/AdminPanel/Controllers/DashboardController.swift
+++ b/Sources/AdminPanel/Controllers/DashboardController.swift
@@ -5,11 +5,11 @@ public protocol DashboardControllerType {
     func renderDashboard(_ req: Request) throws -> Future<Response>
 }
 
-public final class DashboardController: DashboardControllerType {
+public final class DashboardController<U: AdminPanelUserType>: DashboardControllerType {
     public init() {}
 
     public func renderDashboard(_ req: Request) throws -> Future<Response> {
-        let config = try req.make(AdminPanelConfig.self)
+        let config = try req.make(AdminPanelConfig<U>.self)
         let path = config.dashboardPath ?? AdminPanelViews.Dashboard.index
 
         return try req.privateContainer

--- a/Sources/AdminPanel/Controllers/LoginController.swift
+++ b/Sources/AdminPanel/Controllers/LoginController.swift
@@ -16,7 +16,7 @@ public final class LoginController<U: AdminPanelUserType>: LoginControllerType {
     // MARK: Login
 
     public func login(_ req: Request) throws -> Future<Response> {
-        let endpoints = try req.make(AdminPanelConfig.self).endpoints
+        let endpoints = try req.make(AdminPanelConfig<U>.self).endpoints
         return try req
             .content
             .decode(U.Login.self)
@@ -40,7 +40,7 @@ public final class LoginController<U: AdminPanelUserType>: LoginControllerType {
     }
 
     public func renderLogin(_ req: Request) throws -> Future<Response> {
-        let endpoints = try req.make(AdminPanelConfig.self).endpoints
+        let endpoints = try req.make(AdminPanelConfig<U>.self).endpoints
         guard try !req.isAuthenticated(U.self) else {
             return Future.map(on: req) {
                 req.redirect(to: endpoints.dashboard)
@@ -58,7 +58,7 @@ public final class LoginController<U: AdminPanelUserType>: LoginControllerType {
     // MARK: Log out
 
     public func logout(_ req: Request) throws -> Response {
-        let endpoints = try req.make(AdminPanelConfig.self).endpoints
+        let endpoints = try req.make(AdminPanelConfig<U>.self).endpoints
         try req.unauthenticateSession(U.self)
         return req.redirect(to: endpoints.login).flash(.success, "Logged out")
     }

--- a/Sources/AdminPanel/Helpers/UniqueField.swift
+++ b/Sources/AdminPanel/Helpers/UniqueField.swift
@@ -2,25 +2,31 @@ import Fluent
 import Submissions
 import Vapor
 
-public func uniqueField<U: Model>(
-    keyPath: WritableKeyPath<U, String>,
-    value: String?,
-    context: ValidationContext,
-    accept: String? = nil,
-    exceptIn contexts: [ValidationContext] = [],
+public func validateThat<U: Model, T: Encodable & Equatable & CustomDebugStringConvertible>(
+    only entity: U?,
+    has value: T?,
+    for keyPath: KeyPath<U, T>,
     on db: DatabaseConnectable
-) throws -> Future<[ValidationError]> {
+) -> Future<[ValidationError]> {
     guard let value = value else {
-        return Future.transform(to: [], on: db)
+        return db.future([])
     }
 
-    return U.query(on: db)
+    var query = U.query(on: db)
         .filter(keyPath == value)
-        .first()
-        .map(to: [ValidationError].self) { model in
-            let value = model?[keyPath: keyPath]
-            guard model == nil || (value == accept && !contexts.contains(context)) else {
-                return [BasicValidationError("\(value ?? "") already exists")]
+
+    if let entity = entity {
+        query = query.filter(U.idKey != entity[keyPath: U.idKey])
+    }
+
+    return query
+        .count()
+        .map { count in
+            guard count == 0 else {
+                let propertyDescription = try U.reflectProperty(forKey: keyPath)?.description ?? ""
+                let reason = "A model of type '\(U.self)' with value '\(value.debugDescription)' " +
+                    "\(propertyDescription)already exists."
+                return [BasicValidationError(reason)]
             }
             return []
         }

--- a/Sources/AdminPanel/Helpers/UniqueField.swift
+++ b/Sources/AdminPanel/Helpers/UniqueField.swift
@@ -23,9 +23,10 @@ public func validateThat<U: Model, T: Encodable & Equatable & CustomDebugStringC
         .count()
         .map { count in
             guard count == 0 else {
-                let propertyDescription = try U.reflectProperty(forKey: keyPath)?.description ?? ""
-                let reason = "A model of type '\(U.self)' with value '\(value.debugDescription)' " +
-                    "\(propertyDescription)already exists."
+                let reason = """
+                    A model of type \"\(U.self)\" with value \(value.debugDescription)
+                    already exists.
+                """
                 return [BasicValidationError(reason)]
             }
             return []

--- a/Sources/AdminPanel/Models/AdminPanelUser+PasswordResettable.swift
+++ b/Sources/AdminPanel/Models/AdminPanelUser+PasswordResettable.swift
@@ -37,7 +37,7 @@ extension AdminPanelUser: PasswordResettable {
     public struct ResetPassword: HasReadablePassword, RequestCreatable, Submittable {
         public struct Submission: SubmissionType {
             public func fieldEntries() throws -> [FieldEntry<ResetPassword>] {
-                // TODO: add password validator
+                #warning("TODO: add password validator")
                 return try [makeFieldEntry(keyPath: \.password, label: "Password")]
             }
 

--- a/Sources/AdminPanel/Models/AdminPanelUser+PasswordResettable.swift
+++ b/Sources/AdminPanel/Models/AdminPanelUser+PasswordResettable.swift
@@ -37,7 +37,7 @@ extension AdminPanelUser: PasswordResettable {
     public struct ResetPassword: HasReadablePassword, RequestCreatable, Submittable {
         public struct Submission: SubmissionType {
             public func fieldEntries() throws -> [FieldEntry<ResetPassword>] {
-                #warning("TODO: add password validator")
+                // TODO: add password validator
                 return try [makeFieldEntry(keyPath: \.password, label: "Password")]
             }
 

--- a/Sources/AdminPanel/Models/AdminPanelUser+PasswordResettable.swift
+++ b/Sources/AdminPanel/Models/AdminPanelUser+PasswordResettable.swift
@@ -2,19 +2,62 @@ import Fluent
 import Foundation
 import JWT
 import Reset
+import Submissions
 import Sugar
 import Vapor
 
 extension AdminPanelUser: PasswordResettable {
     public typealias JWTPayload = ModelPayload<AdminPanelUser>
 
-    public struct RequestLink: Decodable, HasReadableUsername {
-        public static let readableUsernameKey = \RequestLink.email
+    public struct RequestReset: HasReadableUsername, RequestCreatable, Submittable {
+        public struct Submission: SubmissionType {
+            public func fieldEntries() throws -> [FieldEntry<RequestReset>] {
+                return try [makeFieldEntry(keyPath: \.email, label: "Email", validators: [.email])]
+            }
+
+            public init(_ requestLink: RequestReset?) {
+                self.email = requestLink?.email
+            }
+
+            let email: String?
+        }
+
+        public struct Create: Decodable {
+            let email: String
+        }
+
+        public static let readableUsernameKey = \RequestReset.email
         public let email: String
+
+        public init(_ create: Create) throws {
+            self.email = create.email
+        }
     }
-    public struct ResetPassword: Decodable, HasReadablePassword {
+
+    public struct ResetPassword: HasReadablePassword, RequestCreatable, Submittable {
+        public struct Submission: SubmissionType {
+            public func fieldEntries() throws -> [FieldEntry<ResetPassword>] {
+                // TODO: add password validator
+                return try [makeFieldEntry(keyPath: \.password, label: "Password")]
+            }
+
+            public init(_ resetPassword: ResetPassword?) {
+                self.password = resetPassword?.password
+            }
+
+            let password: String?
+        }
+
+        public struct Create: Decodable {
+            let password: String
+        }
+
         public static let readablePasswordKey = \ResetPassword.password
         public let password: String
+
+        public init(_ create: Create) throws {
+            self.password = create.password
+        }
     }
 
     public func sendPasswordReset(

--- a/Sources/AdminPanel/Models/AdminPanelUser+Submittable.swift
+++ b/Sources/AdminPanel/Models/AdminPanelUser+Submittable.swift
@@ -26,42 +26,40 @@ extension AdminPanelUser: Submittable {
                 makeFieldEntry(
                     keyPath: \Submission.email,
                     label: "Email address",
-                    asyncValidators: [{ value, context, submittable, req in
-                        return try uniqueField(
-                            keyPath: AdminPanelUser.usernameKey,
-                            value: value,
-                            context: context,
-                            accept: submittable?.email,
-                            exceptIn: [.create],
+                    asyncValidators: [{ email, _, adminPanelUser, req in
+                        validateThat(
+                            only: adminPanelUser,
+                            has: email,
+                            for: \AdminPanelUser.email,
                             on: req
                         )
                     }]
                 ),
                 makeFieldEntry(
-                    keyPath: \Submission.name,
+                    keyPath: \.name,
                     label: "Name",
                     validators: [.count(2...191)]
                 ),
                 makeFieldEntry(
-                    keyPath: \Submission.title,
+                    keyPath: \.title,
                     label: "Title",
                     validators: [.count(...191)],
                     isRequired: false
                 ),
                 makeFieldEntry(
-                    keyPath: \Submission.password,
+                    keyPath: \.password,
                     label: "Password",
                     validators: [.count(8...)],
                     isRequired: false
                 ),
                 makeFieldEntry(
-                    keyPath: \Submission.passwordAgain,
+                    keyPath: \.passwordAgain,
                     label: "Password again",
                     validators: [.count(8...)],
                     isRequired: false
                 ),
                 makeFieldEntry(
-                    keyPath: \Submission.shouldResetPassword,
+                    keyPath: \.shouldResetPassword,
                     label: "Should reset password",
                     isRequired: false
                 )

--- a/Sources/AdminPanel/Models/AdminPanelUser.swift
+++ b/Sources/AdminPanel/Models/AdminPanelUser.swift
@@ -40,12 +40,7 @@ public final class AdminPanelUser: Codable {
     }
 }
 
-extension AdminPanelUser: MySQLModel {
-    public static let createdAtKey: TimestampKey? = \AdminPanelUser.createdAt
-    public static let updatedAtKey: TimestampKey? = \AdminPanelUser.updatedAt
-    public static let deletedAtKey: TimestampKey? = \AdminPanelUser.deletedAt
-}
-
 extension AdminPanelUser: Content {}
 extension AdminPanelUser: Migration {}
+extension AdminPanelUser: MySQLModel {}
 extension AdminPanelUser: Parameter {}

--- a/Sources/AdminPanel/Models/AdminPanelUser.swift
+++ b/Sources/AdminPanel/Models/AdminPanelUser.swift
@@ -11,6 +11,10 @@ public final class AdminPanelUser: Codable {
     public var passwordChangeCount: Int
     public var shouldResetPassword: Bool
 
+    public static let createdAtKey = \AdminPanelUser.createdAt
+    public static let updatedAtKey = \AdminPanelUser.updatedAt
+    public static let deletedAtKey = \AdminPanelUser.deletedAt
+
     public var createdAt: Date?
     public var updatedAt: Date?
     public var deletedAt: Date?

--- a/Sources/AdminPanel/Models/AdminPanelUserType.swift
+++ b/Sources/AdminPanel/Models/AdminPanelUserType.swift
@@ -4,11 +4,15 @@ import Submissions
 import Sugar
 
 public protocol AdminPanelUserType:
-    UserType,
+    Parameter,
     PasswordAuthenticatable,
     PasswordResettable,
     SessionAuthenticatable,
-    Parameter
+    Submittable,
+    UserType
+where
+    ID: LosslessStringConvertible,
+    Self.ResolvedParameter == Future<Self>
 {
     var shouldResetPassword: Bool { get }
 }

--- a/Sources/AdminPanel/Providers/AdminPanelProvider.swift
+++ b/Sources/AdminPanel/Providers/AdminPanelProvider.swift
@@ -131,7 +131,7 @@ public final class AdminPanelProvider<U: AdminPanelUserType>: Provider {
             config: container.make()
         )
 
-        let tags: LeafTagConfig = try container.make()
+        let tags: MutableLeafTagConfig = try container.make()
         tags.use([
             "adminpanel:avatarurl": AvatarURLTag(),
             "adminpanel:config": AdminPanelConfigTag(),

--- a/Sources/AdminPanel/Providers/AdminPanelProvider.swift
+++ b/Sources/AdminPanel/Providers/AdminPanelProvider.swift
@@ -1,27 +1,12 @@
-import Vapor
+import Authentication
+import Bootstrap
+import Flash
 import Fluent
 import Leaf
-import Sugar
-import Authentication
-import Flash
-import Bootstrap
 import Reset
 import Submissions
-
-extension AdminPanelProvider {
-    public static var tags: [String: TagRenderer] {
-        return [
-            "adminpanel:config": AdminPanelConfigTag(),
-            "adminpanel:sidebar:menuitem": SidebarMenuItemTag(),
-            "adminpanel:sidebar:heading": SidebarHeadingTag(),
-            "adminpanel:avatarurl": AvatarURLTag(),
-            "adminpanel:user": UserTag()
-        ]
-        .merging(FlashProvider.tags) { (adminpanel, flash) in adminpanel }
-        .merging(BootstrapProvider.tags) { (adminpanel, bootstrap) in adminpanel }
-        .merging(SubmissionsProvider.tags) { (adminpanel, submissions) in adminpanel }
-    }
-}
+import Sugar
+import Vapor
 
 // MARK: - Commands
 extension AdminPanelProvider where U.ID: ExpressibleByStringLiteral, U: Seedable {
@@ -35,11 +20,14 @@ extension AdminPanelProvider where U.ID: ExpressibleByStringLiteral, U: Seedable
 public final class AdminPanelProvider<U: AdminPanelUserType>: Provider {
     /// See Service.Provider.repositoryName
     public static var repositoryName: String { return "admin-panel" }
-    public let config: AdminPanelConfig
+    public let config: AdminPanelConfig<U>
 
     public var middlewares: AdminPanelMiddlewares
 
-    public init(config: AdminPanelConfig) {
+    private let resetProvider: ResetProvider<U>
+    private let submissionsProvider: SubmissionsProvider
+
+    public init(config: AdminPanelConfig<U>) {
         self.config = config
 
         let unsecure: [Middleware] = [
@@ -58,27 +46,6 @@ public final class AdminPanelProvider<U: AdminPanelUserType>: Provider {
             unsecure: unsecure,
             secure: secure
         )
-    }
-
-    private var resetProvider: ResetProvider<U>!
-
-    /// See Service.Provider.Register
-    public func register(_ services: inout Services) throws {
-        try services.register(LeafProvider())
-        try services.register(AuthenticationProvider())
-        services.register(KeyedCacheSessions.self)
-        services.register(config)
-        services.register(AdminPanelConfigTagData(
-            name: config.name,
-            baseUrl: config.baseUrl,
-            userMenuPath: config.userMenuPath,
-            adminMenuPath: config.adminMenuPath,
-            superAdminMenuPath: config.superAdminMenuPath
-        ))
-        try services.register(FlashProvider())
-        try services.register(CurrentURLProvider())
-        try services.register(CurrentUserProvider<U>())
-        try services.register(SubmissionsProvider())
 
         resetProvider = ResetProvider<U>(
             config: .init(
@@ -129,7 +96,29 @@ public final class AdminPanelProvider<U: AdminPanelUserType>: Provider {
                 )
             )
         )
+        submissionsProvider = SubmissionsProvider()
+    }
+
+    /// See Service.Provider.Register
+    public func register(_ services: inout Services) throws {
+        try services.register(AuthenticationProvider())
+        try services.register(BootstrapProvider())
+        try services.register(CurrentURLProvider())
+        try services.register(CurrentUserProvider<U>())
+        try services.register(FlashProvider())
+
         try services.register(resetProvider)
+        try services.register(submissionsProvider)
+
+        services.register(AdminPanelConfigTagData(
+            name: config.name,
+            baseUrl: config.baseUrl,
+            userMenuPath: config.userMenuPath,
+            adminMenuPath: config.adminMenuPath,
+            superAdminMenuPath: config.superAdminMenuPath
+        ))
+        services.register(config)
+        services.register(KeyedCacheSessions.self)
     }
 
     /// See Service.Provider.boot
@@ -141,6 +130,15 @@ public final class AdminPanelProvider<U: AdminPanelUserType>: Provider {
             resetProvider: resetProvider,
             config: container.make()
         )
+
+        let tags: LeafTagConfig = try container.make()
+        tags.use([
+            "adminpanel:avatarurl": AvatarURLTag(),
+            "adminpanel:config": AdminPanelConfigTag(),
+            "adminpanel:sidebar:heading": SidebarHeadingTag(),
+            "adminpanel:sidebar:menuitem": SidebarMenuItemTag(),
+            "adminpanel:user": UserTag()
+        ])
 
         return .done(on: container)
     }

--- a/Sources/AdminPanel/Tags/CurrentUserTag.swift
+++ b/Sources/AdminPanel/Tags/CurrentUserTag.swift
@@ -3,15 +3,15 @@ import Leaf
 import Sugar
 import TemplateKit
 
+#warning("TODO: make this compatible with generic user")
 public final class UserTag: TagRenderer {
-    public func render(tag: TagContext) throws -> EventLoopFuture<TemplateData> {
+    public func render(tag: TagContext) throws -> Future<TemplateData> {
         try tag.requireParameterCount(1)
         let container = try tag.container.make(CurrentUserContainer<AdminPanelUser>.self)
 
         return Future.map(on: tag) {
             try container.user?.viewData(for: tag.parameters[0], tag: tag) ?? .null
         }
-
     }
 }
 
@@ -35,15 +35,15 @@ private extension AdminPanelUser {
 
         switch parsedKey {
         case .id:
-            return id == nil ? .null : .int(id!)
+            return id.map(TemplateData.int) ?? .null
         case .email:
             return .string(email)
         case .name:
             return .string(name)
         case .title:
-            return title == nil ? .null: .string(title!)
+            return title.map(TemplateData.string) ?? .null
         case .avatarUrl:
-            return avatarUrl == nil ? .null: .string(avatarUrl!)
+            return avatarUrl.map(TemplateData.string) ?? .null
         }
     }
 }

--- a/Sources/AdminPanel/Tags/CurrentUserTag.swift
+++ b/Sources/AdminPanel/Tags/CurrentUserTag.swift
@@ -3,7 +3,7 @@ import Leaf
 import Sugar
 import TemplateKit
 
-#warning("TODO: make this compatible with generic user")
+// TODO: make this compatible with generic user
 public final class UserTag: TagRenderer {
     public func render(tag: TagContext) throws -> Future<TemplateData> {
         try tag.requireParameterCount(1)

--- a/Sources/AdminPanel/Tags/SidebarMenuItemTag.swift
+++ b/Sources/AdminPanel/Tags/SidebarMenuItemTag.swift
@@ -52,7 +52,6 @@ public final class SidebarMenuItemTag: TagRenderer {
     }
 }
 
-
 private extension SidebarMenuItemTag {
     func isActive(currentPath: String, pathPatterns: ArraySlice<TemplateData>) -> Bool {
         for arg in pathPatterns {

--- a/Sources/AdminPanel/routes.swift
+++ b/Sources/AdminPanel/routes.swift
@@ -57,7 +57,7 @@ internal extension AdminPanelProvider {
         middlewares: AdminPanelMiddlewares,
         endpoints: AdminPanelEndpoints,
         resetProvider: ResetProvider<U>,
-        config: AdminPanelConfig
+        config: AdminPanelConfig<U>
     ) throws {
 
         let unprotected = router.grouped(middlewares.unsecure)

--- a/Tests/AdminPanelTests/AdminPanelTests.swift
+++ b/Tests/AdminPanelTests/AdminPanelTests.swift
@@ -6,7 +6,7 @@ final class AdminPanelTests: XCTestCase {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct
         // results.
-        XCTAssertEqual(AdminPanel().text, "Hello, World!")
+        XCTAssertTrue(true)
     }
 
 


### PR DESCRIPTION
Do not merge! This is awaiting https://github.com/nodes-vapor/sugar/pull/56 (or https://github.com/vapor/leaf/pull/113).

- vaidatable password reset (login and register next?)
- improve unique field validation
- add further constraints to AdminPanelUserType
- register tags in new proposed way
- avoid ! in provider
- make
- clean up CurrentUserTag
- support custom user in config and dashboard controller