### PR TITLE
add new leaf tag from Sugar to format a number to fixed decimals

### DIFF
--- a/Sources/AdminPanel/Providers/AdminPanelProvider.swift
+++ b/Sources/AdminPanel/Providers/AdminPanelProvider.swift
@@ -139,7 +139,7 @@ public extension LeafTagConfig {
             "adminPanel:user": CurrentUserTag<U>(),
             "adminPanel:user:requireRole": RequireRoleTag<U>(),
             "adminPanel:user:hasRequiredRole": HasRequiredRole<U>(),
-            "numberformat": NumberFormatTag(),
+            "number": NumberFormatTag(),
             "offsetPaginator": OffsetPaginatorTag(templatePath: "Paginator/offsetpaginator"),
             "submissions:WYSIWYG": InputTag(templatePath: paths.wysiwygField)
         ])

--- a/Sources/AdminPanel/Providers/AdminPanelProvider.swift
+++ b/Sources/AdminPanel/Providers/AdminPanelProvider.swift
@@ -139,6 +139,7 @@ public extension LeafTagConfig {
             "adminPanel:user": CurrentUserTag<U>(),
             "adminPanel:user:requireRole": RequireRoleTag<U>(),
             "adminPanel:user:hasRequiredRole": HasRequiredRole<U>(),
+            "numberformat": NumberFormatTag(),
             "offsetPaginator": OffsetPaginatorTag(templatePath: "Paginator/offsetpaginator"),
             "submissions:WYSIWYG": InputTag(templatePath: paths.wysiwygField)
         ])


### PR DESCRIPTION
what do you think of the naming? Should we maybe instead call it `number:format` or `number:decimals` so we in the future can add more types for example `number:currency` or something ? 